### PR TITLE
fix: Correct use of object URL in src tag for pdf view

### DIFF
--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -44,7 +44,7 @@
           mat-icon-button
           color="primary"
           [matMenuTriggerFor]="downloadMenu"
-          [disabled]="!hash"
+          [disabled]="!token"
           title="Download"
         >
           <mat-icon>file_download</mat-icon>

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -32,7 +32,7 @@ export class EditorComponent implements OnInit {
   editorTextChanged: Subject<string> = new Subject<string>();
 
   previewUrl: any;
-  hash: string = ''; // = id for downloading
+  token: string = ''; // = id for downloading
 
   autorenew: boolean = false;
 
@@ -125,8 +125,8 @@ export class EditorComponent implements OnInit {
    * @param      {string}  extension  The extension
    */
   download(extension: string): void {
-    if (!extension || !this.hash) return;
-    window.open(ApiConfig.url + '/api/download/' + this.hash + '/' + extension, '_blank');
+    if (!extension || !this.token) return;
+    window.open(ApiConfig.url + '/api/download/' + this.token + '/' + extension, '_blank');
   }
 
   /**
@@ -139,11 +139,11 @@ export class EditorComponent implements OnInit {
     this.loading = true;
     this.editorService.generate(text, this.params)
       .subscribe(
-        res => {
+        token => {
           this.loading = false;
           this.errorPreview = '';
-          this.hash = res['hash'];
-          this.previewUrl = this.sanitizer.bypassSecurityTrustResourceUrl('data:application/pdf;base64,' + res['base64']);
+          this.token = token;
+          this.previewUrl = this.sanitizer.bypassSecurityTrustResourceUrl(ApiConfig.url + '/temp/' + token + '.pdf');
         },
         err => {
           this.loading = false;


### PR DESCRIPTION
comes together with https://github.com/olastor/paperify-backend/pull/2
fixes #13 